### PR TITLE
Exposed a Namespace instance to allow registration of filters and tags

### DIFF
--- a/Sources/KituraStencilTemplateEngine.swift
+++ b/Sources/KituraStencilTemplateEngine.swift
@@ -20,8 +20,11 @@ import PathKit
 
 public class StencilTemplateEngine: TemplateEngine {
     public var fileExtension: String { return "stencil" }
-    public var namespace = Namespace()
-    public init() {}
+    private let namespace: Namespace
+
+    public init(namespace: Namespace = Namespace()) {
+        self.namespace = namespace
+    }
 
     public func render(filePath: String, context: [String: Any]) throws -> String {
         let templatePath = Path(filePath)

--- a/Sources/KituraStencilTemplateEngine.swift
+++ b/Sources/KituraStencilTemplateEngine.swift
@@ -20,6 +20,7 @@ import PathKit
 
 public class StencilTemplateEngine: TemplateEngine {
     public var fileExtension: String { return "stencil" }
+    public var namespace = Namespace()
     public init() {}
 
     public func render(filePath: String, context: [String: Any]) throws -> String {
@@ -29,6 +30,6 @@ public class StencilTemplateEngine: TemplateEngine {
         let loader = TemplateLoader(paths: [templateDirectory])
         var context = context
         context["loader"] = loader
-        return try template.render(Context(dictionary: context))
+        return try template.render(Context(dictionary: context, namespace: namespace))
     }
 }


### PR DESCRIPTION
Sorry for the rush job – this is what I was thinking. It lets developers register filters and tags on the default `StencilTemplateEngine` class rather than having to create their own `TemplateEngine` class.