### PR TITLE
Restore Swift 3.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,26 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+    - os: osx
+      osx_image: xcode8.3
+      sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
     - os: osx
       osx_image: xcode9.2
       sudo: required
+    - os: osx
+      osx_image: xcode9.3beta
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+# 4.1 build disabled pending 4.1 support from Stencil and PathKit
+#    - os: linux
+#      dist: trusty
+#      sudo: required
+#      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
     - os: osx
       osx_image: xcode8.3
       sudo: required
@@ -28,10 +29,11 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
-    - os: osx
-      osx_image: xcode9.3beta
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+# 4.1 build disabled pending 4.1 support from Stencil and PathKit
+#    - os: osx
+#      osx_image: xcode9.3beta
+#      sudo: required
+#      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,5 @@
+{
+  "autoPin": false,
+  "pins": [],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,6 @@ let package = Package(
     name: "KituraStencil",
     dependencies: [
         .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 1, minor: 7),
-        .Package(url: "https://github.com/kylef/Stencil", majorVersion: 0, minor: 10)
+        .Package(url: "https://github.com/kylef/Stencil.git", majorVersion: 0, minor: 10)
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016, 2017
+ * Copyright IBM Corporation 2016, 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,5 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 /**
- * Copyright IBM Corporation 2016, 2018
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,24 +18,8 @@ import PackageDescription
 
 let package = Package(
     name: "KituraStencil",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "KituraStencil",
-            targets: ["KituraStencil"]
-        )
-    ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
-        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.10.0"))
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "KituraStencil",
-            dependencies: ["KituraTemplateEngine", "Stencil"]
-        )
+        .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 1, minor: 7),
+        .Package(url: "https://github.com/kylef/Stencil", majorVersion: 0, minor: 10)
     ]
 )
-

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,44 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+/**
+ * Copyright IBM Corporation 2016, 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import PackageDescription
+
+let package = Package(
+    name: "KituraStencil",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KituraStencil",
+            targets: ["KituraStencil"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0")),
+        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.10.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "KituraStencil",
+            dependencies: ["KituraTemplateEngine", "Stencil"]
+        )
+    ]
+)
+

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.3")),
         .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.10.0"))
     ],
     targets: [


### PR DESCRIPTION
- Restore the Swift 3 format `Package.swift`, adding the missing `.git` extension (as per #23)
- Rename `Package@swift-4.0.swift` to `Package@swift-4.swift` for compatibility with Swift 4.1
- Update Travis to test 3.1.1 and 4.1 snapshots

Although Travis for 3.1.1 and 4.1 has been added,  I have disabled 4.1 pending Swift 4.1 compatibility from Stencil and its dependents (notably PathKit, which currently fails to compile).

This also reverts the Kitura-TemplateEngine dependency back to 1.7 (the same as the current latest tag 1.8.4) as we decided not to make a 2.0 release.