### PR TITLE
Support Swift 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,10 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-# 4.1 build disabled pending 4.1 support from Stencil and PathKit
-#    - os: linux
-#      dist: trusty
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1
     - os: osx
       osx_image: xcode8.3
       sudo: required
@@ -29,11 +28,10 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
-# 4.1 build disabled pending 4.1 support from Stencil and PathKit
-#    - os: osx
-#      osx_image: xcode9.3beta
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+    - os: osx
+      osx_image: xcode9.3beta
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.3")),
-        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.10.0"))
+        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.11.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Increase the minor version of Stencil to 0.11, which in turn depends on PathKit 0.9, in order to compile with Swift 4.1.

Also enable Travis on Swift 4.1.