### PR TITLE
Add Swift 4.2 snapshots to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,22 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-26-a
     - os: osx
       osx_image: xcode9.2
       sudo: required
       env: SWIFT_SNAPSHOT=4.0.3
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT:4.1 JAZZY_ELIGIBLE=true
+      env: JAZZY_ELIGIBLE=true
+    - os: osx
+      osx_image: xcode9.4
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-04-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package.pins
+++ b/Package.pins
@@ -1,5 +1,0 @@
-{
-  "autoPin": false,
-  "pins": [],
-  "version": 1
-}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ A templating engine for Kitura that uses Stencil-based templates.
 ## Summary
 Kitura-StencilTemplateEngine is a plugin for [Kitura Template Engine](https://github.com/IBM-Swift/Kitura-TemplateEngine.git) for using [Stencil](https://github.com/kylef/Stencil) with the [Kitura](https://github.com/IBM-Swift/Kitura) server framework. This makes it easy to use Stencil templating, with a Kitura server, to create an HTML page with integrated Swift variables.
 
+## Swift version
+The latest version of Kitura-StencilTemplateEngine requires **Swift 4.0** or newer. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
+
 ## Stencil Template File
 The template file is basically HTML with gaps where we can insert code and variables. [Stencil](https://github.com/kylef/Stencil) is a templating language used to write a template file and Kitura-StencilTemplateEngine can use any standard Stencil template.
 


### PR DESCRIPTION
- Add latest Swift 4.2 snapshot to Travis (Linux)
- Add Swift 4.2 06-04-a snapshot for macOS (the latest supported under Xcode 9.4)
- State minimum supported Swift version in README