### PR TITLE
Update to Stencil 0.13 for Swift >4.0

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
-        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.13.0"))
+        .package(url: "https://github.com/kylef/Stencil.git", .upToNextMinor(from: "0.11.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**


### PR DESCRIPTION
Stencil 0.13 fixes a number of compilation warnings when compiling on Swift 4.0 or higher.  It also contains a number of (non-breaking) enhancements.  This PR moves us up to that version.

Unfortunately Stencil 0.13.1 (the current latest tag) is incompatible with Swift 4.0, as it relies on 4.1 features.  [A PR has been merged](https://github.com/stencilproject/Stencil/pull/258) to restore 4.0 support, but this has not yet been tagged.  In the meantime we can continue to use Stencil 0.11 when building with Swift 4.0.

- `Package.swift` updated to `swift-tools-version:4.2` and Stencil 0.13
- `Package@swift-4.0.swift` (Stencil 0.11) and `Package@swift-4.1.swift` (Stencil 0.13) added.